### PR TITLE
Infinite carousel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -90,11 +90,7 @@ function App() {
             ref={introductionRef}
           />
         ) : null}
-        <Portfolio
-          ref={portfolioRef}
-          homeScreenVisible={!removePage}
-          scrollY={scrollY}
-        />
+        <Portfolio ref={portfolioRef} />
         <TimeLine ref={timeLineRef} />
         <Contact ref={contactRef} />
         <Footer />

--- a/src/components/icons/Icons.jsx
+++ b/src/components/icons/Icons.jsx
@@ -99,3 +99,37 @@ export const Cross = () => (
     />
   </svg>
 );
+
+export const LeftArrow = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={2.5}
+    stroke="currentColor"
+    className="h-6 w-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 19.5L8.25 12l7.5-7.5"
+    />
+  </svg>
+);
+
+export const RightArrow = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={2.5}
+    stroke="currentColor"
+    className="h-6 w-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M8.25 4.5l7.5 7.5-7.5 7.5"
+    />
+  </svg>
+);

--- a/src/components/sections/Portfolio.jsx
+++ b/src/components/sections/Portfolio.jsx
@@ -45,7 +45,7 @@ const Portfolio = forwardRef((props, ref) => {
     <section ref={ref}>
       <Title>Portfolio</Title>
       <CarouselBigScreens>
-        {portfolioCarousel.map((project) => (
+        {portfolio.map((project) => (
           <CarouselBigScreensItem key={project.id}>
             <PortfolioItem
               id={project.id}

--- a/src/components/sections/Portfolio.jsx
+++ b/src/components/sections/Portfolio.jsx
@@ -23,11 +23,11 @@ const portfolioCarousel = [
   },
 ];
 
-const Portfolio = forwardRef(({ homeScreenVisible, scrollY }, ref) => {
+const Portfolio = forwardRef((props, ref) => {
   return (
     <section ref={ref}>
       <Title>Portfolio</Title>
-      <Carousel homeScreenVisible={homeScreenVisible} scrollY={scrollY}>
+      <Carousel>
         {portfolioCarousel.map((project) => (
           <CarouselItem key={project.id}>
             <PortfolioItem

--- a/src/components/sections/Portfolio.jsx
+++ b/src/components/sections/Portfolio.jsx
@@ -5,12 +5,30 @@ import PortfolioItem from "../helpers/PortfolioItem";
 import Title from "../utility/Title";
 import Carousel, { CarouselItem } from "../utility/Carousel";
 
+const portfolioCarousel = [
+  {
+    id: -1,
+    title: portfolio[portfolio.length - 1].title,
+    imgUrl: portfolio[portfolio.length - 1].imgUrl,
+    stack: portfolio[portfolio.length - 1].stack,
+    link: portfolio[portfolio.length - 1].link,
+  },
+  ...portfolio,
+  {
+    id: portfolio.length,
+    title: portfolio[0].title,
+    imgUrl: portfolio[0].imgUrl,
+    stack: portfolio[0].stack,
+    link: portfolio[0].link,
+  },
+];
+
 const Portfolio = forwardRef(({ homeScreenVisible, scrollY }, ref) => {
   return (
     <section ref={ref}>
       <Title>Portfolio</Title>
       <Carousel homeScreenVisible={homeScreenVisible} scrollY={scrollY}>
-        {portfolio.map((project) => (
+        {portfolioCarousel.map((project) => (
           <CarouselItem key={project.id}>
             <PortfolioItem
               id={project.id}

--- a/src/components/sections/Portfolio.jsx
+++ b/src/components/sections/Portfolio.jsx
@@ -3,7 +3,7 @@ import { forwardRef } from "react";
 import portfolio from "../../data/portfolio";
 import PortfolioItem from "../helpers/PortfolioItem";
 import Title from "../utility/Title";
-import Carousel, { CarouselItem } from "../utility/Carousel";
+import CarouselPhone, { CarouselPhoneItem } from "../utility/CarouselPhone";
 
 const portfolioCarousel = [
   {
@@ -27,9 +27,9 @@ const Portfolio = forwardRef((props, ref) => {
   return (
     <section ref={ref}>
       <Title>Portfolio</Title>
-      <Carousel>
+      <CarouselPhone>
         {portfolioCarousel.map((project) => (
-          <CarouselItem key={project.id}>
+          <CarouselPhoneItem key={project.id}>
             <PortfolioItem
               id={project.id}
               imgUrl={project.imgUrl}
@@ -37,9 +37,9 @@ const Portfolio = forwardRef((props, ref) => {
               stack={project.stack}
               link={project.link}
             />
-          </CarouselItem>
+          </CarouselPhoneItem>
         ))}
-      </Carousel>
+      </CarouselPhone>
     </section>
   );
 });

--- a/src/components/sections/Portfolio.jsx
+++ b/src/components/sections/Portfolio.jsx
@@ -1,9 +1,12 @@
-import { forwardRef } from "react";
+import { forwardRef, useState, useEffect } from "react";
 
 import portfolio from "../../data/portfolio";
 import PortfolioItem from "../helpers/PortfolioItem";
 import Title from "../utility/Title";
 import CarouselPhone, { CarouselPhoneItem } from "../utility/CarouselPhone";
+import CarouselBigScreens, {
+  CarouselBigScreensItem,
+} from "../utility/CarouselBigScreens";
 
 const portfolioCarousel = [
   {
@@ -24,7 +27,38 @@ const portfolioCarousel = [
 ];
 
 const Portfolio = forwardRef((props, ref) => {
-  return (
+  const [windowWidth, windowWidthHandler] = useState(window.innerWidth);
+
+  useEffect(() => {
+    function handleWindowResize() {
+      windowWidthHandler(window.innerWidth);
+    }
+
+    window.addEventListener("resize", handleWindowResize);
+
+    return () => {
+      window.removeEventListener("resize", handleWindowResize);
+    };
+  }, [windowWidth]);
+
+  return windowWidth > 1024 ? (
+    <section ref={ref}>
+      <Title>Portfolio</Title>
+      <CarouselBigScreens>
+        {portfolioCarousel.map((project) => (
+          <CarouselBigScreensItem key={project.id}>
+            <PortfolioItem
+              id={project.id}
+              imgUrl={project.imgUrl}
+              title={project.title}
+              stack={project.stack}
+              link={project.link}
+            />
+          </CarouselBigScreensItem>
+        ))}
+      </CarouselBigScreens>
+    </section>
+  ) : (
     <section ref={ref}>
       <Title>Portfolio</Title>
       <CarouselPhone>

--- a/src/components/utility/Carousel.jsx
+++ b/src/components/utility/Carousel.jsx
@@ -147,6 +147,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     }
   };
 
+  // Translate bullets' Carousel
   const translateBullets = () => {
     // No need to translate when we have less than 5 items
     if (nonRepeatingChildrenNumber <= 5) {
@@ -183,6 +184,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     }
   };
 
+  // Conditions to display small inactive button
   const smallNonActiveButtonConditions = (index) => {
     return (
       // Right side of activeIndex - middle
@@ -203,6 +205,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     );
   };
 
+  // Conditions to display extra small inactive button
   const extraSmallNonActiveButtonConditions = (index) => {
     return (
       // Right side of activeIndex - Middle
@@ -247,7 +250,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
         onMouseEnter={() => pauseHandler(true)}
         onMouseLeave={() => pauseHandler(false)}
         className={`whitespace-nowrap ${
-          infiniteLoop ? "" : "transition-transform duration-700"
+          infiniteLoop ? "" : "transition-transform duration-[600ms]"
         }`}
         style={{
           transform: `translateX(-${activeIndex * 100}%)`,
@@ -261,7 +264,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
       <div className="mx-auto mt-6 w-[150px] overflow-hidden">
         <div
           className={`whitespace-nowrap ${
-            infiniteLoop ? "" : "transition-transform duration-700"
+            infiniteLoop ? "" : "transition-transform duration-[600ms]"
           }`}
           style={{
             transform: translateBullets(),
@@ -340,9 +343,11 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
 //   }
 // }, [activeIndex, pause, windowWidth]);
 
+// Update Index with loop
+
 export const ActiveButton = (key) => (
   <div className="inline-block w-[30px] text-center">
-    <button
+    <div
       key={key}
       className={"h-3 w-3 rounded-full bg-bgDark-500 dark:bg-bgDark-400"}
     />
@@ -351,7 +356,7 @@ export const ActiveButton = (key) => (
 
 export const NonActiveButton = (key) => (
   <div className="inline-block w-[30px] text-center">
-    <button
+    <div
       key={key}
       className={"h-3 w-3 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
     />
@@ -359,7 +364,7 @@ export const NonActiveButton = (key) => (
 );
 export const NonActiveButtonS = (key) => (
   <div className="inline-block w-[30px] text-center">
-    <button
+    <div
       key={key}
       className={"h-2 w-2 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
     />
@@ -368,7 +373,7 @@ export const NonActiveButtonS = (key) => (
 
 export const NonActiveButtonXS = (key) => (
   <div className="inline-block w-[30px] text-center">
-    <button
+    <div
       key={key}
       className={"h-1 w-1 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
     />

--- a/src/components/utility/Carousel.jsx
+++ b/src/components/utility/Carousel.jsx
@@ -12,7 +12,7 @@ export const CarouselItem = ({ children }) => {
 
 const Carousel = ({ children, homeScreenVisible, scrollY }) => {
   const childrenNumber = React.Children.count(children);
-  const nonReapeatingChildrenNumber = childrenNumber - 2;
+  const nonRepeatingChildrenNumber = childrenNumber - 2;
 
   const stopPixel = 250;
   // TailwindCSS default values
@@ -147,8 +147,101 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     }
   };
 
+  const translateBullets = () => {
+    // No need to translate when we have less than 5 items
+    if (nonRepeatingChildrenNumber <= 5) {
+      return "";
+    }
+
+    if (nonRepeatingChildrenNumber > 5) {
+      //  Do not translate on start
+      if (activeIndex <= 3 && activeIndex != 0) {
+        return "";
+      }
+
+      // Do not translate on end
+      if (
+        activeIndex >= nonRepeatingChildrenNumber - 2 &&
+        activeIndex != nonRepeatingChildrenNumber + 1
+      ) {
+        return `translateX(-${(nonRepeatingChildrenNumber - 5) * 30}px)`;
+      }
+
+      // Loops' end - Right translation
+      if (activeIndex == nonRepeatingChildrenNumber + 1) {
+        return "";
+      }
+
+      // Loops' start - Left translation
+      if (activeIndex == 0) {
+        return `translateX(-${(nonRepeatingChildrenNumber - 5) * 30}px)`;
+      }
+
+      // Translate Left
+
+      return `translateX(-${(activeIndex - 3) * 30}px)`;
+    }
+  };
+
+  const smallNonActiveButtonConditions = (index) => {
+    return (
+      // Right side of activeIndex - middle
+      (index - activeIndex === 1 &&
+        activeIndex > 3 &&
+        activeIndex <= nonRepeatingChildrenNumber - 3) ||
+      // Right side of activeIndex - start
+      (activeIndex <= 3 && index === 4) ||
+      (activeIndex == nonRepeatingChildrenNumber + 1 && index === 4) ||
+      // Left side of activeIndex - middle
+      (nonRepeatingChildrenNumber - activeIndex >= 3 &&
+        activeIndex >= 4 &&
+        index === activeIndex - 1) ||
+      // Left side of activeIndex - start
+      (nonRepeatingChildrenNumber - activeIndex <= 3 &&
+        index === nonRepeatingChildrenNumber - 3) ||
+      (activeIndex == 0 && index === nonRepeatingChildrenNumber - 3)
+    );
+  };
+
+  const extraSmallNonActiveButtonConditions = (index) => {
+    return (
+      // Right side of activeIndex - Middle
+      (index - activeIndex >= 2 &&
+        activeIndex > 3 &&
+        activeIndex != 0 &&
+        activeIndex < nonRepeatingChildrenNumber - 3) ||
+      (activeIndex == nonRepeatingChildrenNumber - 3 &&
+        index === nonRepeatingChildrenNumber - 1) ||
+      // Right side of activeIndex - Start
+      (activeIndex <= 3 && activeIndex != 0 && index >= 5) ||
+      // Right side of activeIndex - Start Loop
+      (activeIndex == nonRepeatingChildrenNumber + 1 && index === 5) ||
+      // Left side of activeIndex - Middle
+      (nonRepeatingChildrenNumber - activeIndex >= 3 &&
+        activeIndex > 4 &&
+        activeIndex != 0 &&
+        index <= activeIndex - 2) ||
+      (activeIndex === 4 && index === 2) ||
+      // Left side of activeIndex - Start
+      (nonRepeatingChildrenNumber - activeIndex <= 3 &&
+        activeIndex != nonRepeatingChildrenNumber + 1 &&
+        index <= nonRepeatingChildrenNumber - 4 &&
+        index != 1) ||
+      // Left side of activeIndex - Start Loop
+      (activeIndex == 0 && index === nonRepeatingChildrenNumber - 4) ||
+      // Middle Loop
+      (nonRepeatingChildrenNumber >= 11 &&
+        index >= 5 &&
+        index <= nonRepeatingChildrenNumber - 4 &&
+        (activeIndex == 0 ||
+          activeIndex == nonRepeatingChildrenNumber + 1 ||
+          activeIndex == 1 ||
+          activeIndex == nonRepeatingChildrenNumber))
+    );
+  };
+
   return (
-    <div>
+    <div className="overflow-hidden">
       <div
         {...handlers}
         onMouseEnter={() => pauseHandler(true)}
@@ -165,13 +258,28 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
         })}
       </div>
 
-      <div className="mx-auto mt-6 flex w-64 items-center justify-center border-2 border-red-500">
-        <div className="flex w-9/12 flex-row flex-wrap items-center justify-center gap-y-4 gap-x-5 min-[320px]:w-7/12 min-[390px]:w-5/12 min-[500px]:w-4/12">
+      <div className="mx-auto mt-6 w-[150px] overflow-hidden">
+        <div
+          className={`whitespace-nowrap ${
+            infiniteLoop ? "" : "transition-transform duration-700"
+          }`}
+          style={{
+            transform: translateBullets(),
+          }}
+        >
           {React.Children.map(children, (child, index) => {
-            if (index === carouselIndex(activeIndex)) {
-              return <ActiveButton key={index} />;
-            } else {
-              return <NonActiveButton key={index} />;
+            if (index > 0 && index < pageNumber - 1) {
+              if (index === carouselIndex(activeIndex)) {
+                return <ActiveButton key={index} />;
+              } else {
+                if (smallNonActiveButtonConditions(index)) {
+                  return <NonActiveButtonS key={index} />;
+                } else if (extraSmallNonActiveButtonConditions(index)) {
+                  return <NonActiveButtonXS key={index} />;
+                } else {
+                  return <NonActiveButton key={index} />;
+                }
+              }
             }
           })}
         </div>
@@ -188,11 +296,11 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
 //       }
 
 //       if (index !== carouselIndex(activeIndex)) {
-//         if (nonReapeatingChildrenNumber <= 5) {
+//         if (nonRepeatingChildrenNumber <= 5) {
 //           return <NonActiveButton />;
 //         }
 
-//         if (nonReapeatingChildrenNumber <= 6) {
+//         if (nonRepeatingChildrenNumber <= 6) {
 //           if (index === 7) {
 //             return <NonActiveButtonS />;
 //           } else {
@@ -233,30 +341,38 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
 // }, [activeIndex, pause, windowWidth]);
 
 export const ActiveButton = (key) => (
-  <button
-    key={key}
-    className={"h-3 w-3 rounded-full bg-bgDark-500 dark:bg-bgDark-400"}
-  />
+  <div className="inline-block w-[30px] text-center">
+    <button
+      key={key}
+      className={"h-3 w-3 rounded-full bg-bgDark-500 dark:bg-bgDark-400"}
+    />
+  </div>
 );
 
 export const NonActiveButton = (key) => (
-  <button
-    key={key}
-    className={"h-3 w-3 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
-  />
+  <div className="inline-block w-[30px] text-center">
+    <button
+      key={key}
+      className={"h-3 w-3 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
+    />
+  </div>
 );
 export const NonActiveButtonS = (key) => (
-  <button
-    key={key}
-    className={"h-2 w-2 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
-  />
+  <div className="inline-block w-[30px] text-center">
+    <button
+      key={key}
+      className={"h-2 w-2 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
+    />
+  </div>
 );
 
 export const NonActiveButtonXS = (key) => (
-  <button
-    key={key}
-    className={"h-1 w-1 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
-  />
+  <div className="inline-block w-[30px] text-center">
+    <button
+      key={key}
+      className={"h-1 w-1 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
+    />
+  </div>
 );
 
 export default Carousel;

--- a/src/components/utility/Carousel.jsx
+++ b/src/components/utility/Carousel.jsx
@@ -42,7 +42,6 @@ const Carousel = ({ children }) => {
 
   // Illusion for infinite loop - Active Index Cycle
   useEffect(() => {
-    console.log(infiniteLoop);
     if (infiniteLoop) {
       if (activeIndex == childrenNumber - 1) {
         updateIndex(1);
@@ -190,7 +189,7 @@ const Carousel = ({ children }) => {
   };
 
   const ActiveButton = ({ index }) => (
-    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+    <div className="inline-block w-[30px] text-center">
       <button
         key={index}
         className={
@@ -201,7 +200,7 @@ const Carousel = ({ children }) => {
   );
 
   const NonActiveButton = ({ index }) => (
-    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+    <div className="inline-block w-[30px] text-center">
       <button
         key={index}
         onClick={() => updateIndex(index)}
@@ -213,7 +212,7 @@ const Carousel = ({ children }) => {
   );
 
   const NonActiveButtonS = ({ index }) => (
-    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+    <div className="inline-block w-[30px] text-center">
       <button
         key={index}
         onClick={() => updateIndex(index)}
@@ -225,7 +224,7 @@ const Carousel = ({ children }) => {
   );
 
   const NonActiveButtonXS = ({ index }) => (
-    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+    <div className="inline-block w-[30px] text-center">
       <button
         key={index}
         onClick={() => updateIndex(index)}
@@ -252,7 +251,7 @@ const Carousel = ({ children }) => {
           return child;
         })}
       </div>
-      <div className="mx-auto mt-6 h-fit w-[150px] overflow-hidden border-2 border-red-500">
+      <div className="mx-auto mt-6 h-fit w-[150px] overflow-hidden">
         <div
           className={`whitespace-nowrap ${
             infiniteLoop ? "" : "transition-transform duration-[600ms]"

--- a/src/components/utility/Carousel.jsx
+++ b/src/components/utility/Carousel.jsx
@@ -243,6 +243,53 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     );
   };
 
+  const ActiveButton = ({ index }) => (
+    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+      <button
+        key={index}
+        className={
+          "h-[0.78rem] w-[0.78rem] rounded-full bg-bgDark-500 align-middle dark:bg-bgDark-400"
+        }
+      />
+    </div>
+  );
+
+  const NonActiveButton = ({ index }) => (
+    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+      <button
+        key={index}
+        onClick={() => updateIndex(index)}
+        className={
+          "h-3 w-3 rounded-full bg-bgDark-300 align-middle dark:bg-bgDark-600"
+        }
+      />
+    </div>
+  );
+
+  const NonActiveButtonS = ({ index }) => (
+    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+      <button
+        key={index}
+        onClick={() => updateIndex(index)}
+        className={
+          "h-2 w-2 rounded-full bg-bgDark-300 align-middle dark:bg-bgDark-600"
+        }
+      />
+    </div>
+  );
+
+  const NonActiveButtonXS = ({ index }) => (
+    <div className="inline-block w-[30px] border-2 border-green-500 text-center">
+      <button
+        key={index}
+        onClick={() => updateIndex(index)}
+        className={
+          "h-1 w-1 rounded-full bg-bgDark-300 align-middle dark:bg-bgDark-600"
+        }
+      />
+    </div>
+  );
+
   return (
     <div className="overflow-hidden">
       <div
@@ -261,7 +308,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
         })}
       </div>
 
-      <div className="mx-auto mt-6 w-[150px] overflow-hidden">
+      <div className="mx-auto mt-6 h-fit w-[150px] overflow-hidden border-2 border-red-500">
         <div
           className={`whitespace-nowrap ${
             infiniteLoop ? "" : "transition-transform duration-[600ms]"
@@ -273,14 +320,14 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
           {React.Children.map(children, (child, index) => {
             if (index > 0 && index < pageNumber - 1) {
               if (index === carouselIndex(activeIndex)) {
-                return <ActiveButton key={index} />;
+                return <ActiveButton index={index} />;
               } else {
                 if (smallNonActiveButtonConditions(index)) {
-                  return <NonActiveButtonS key={index} />;
+                  return <NonActiveButtonS index={index} />;
                 } else if (extraSmallNonActiveButtonConditions(index)) {
-                  return <NonActiveButtonXS key={index} />;
+                  return <NonActiveButtonXS index={index} />;
                 } else {
-                  return <NonActiveButton key={index} />;
+                  return <NonActiveButton index={index} />;
                 }
               }
             }
@@ -290,94 +337,5 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     </div>
   );
 };
-
-// {
-//   React.Children.map(children, (child, index) => {
-//     if (index < pageNumber - 1 && index > 0 && index <= 6) {
-//       if (index === carouselIndex(activeIndex)) {
-//         return <ActiveButton />;
-//       }
-
-//       if (index !== carouselIndex(activeIndex)) {
-//         if (nonRepeatingChildrenNumber <= 5) {
-//           return <NonActiveButton />;
-//         }
-
-//         if (nonRepeatingChildrenNumber <= 6) {
-//           if (index === 7) {
-//             return <NonActiveButtonS />;
-//           } else {
-//             return <NonActiveButtonXS />;
-//           }
-//         }
-//       }
-//     }
-//   });
-// }
-
-// // Carousel Animation
-// useEffect(() => {
-//   if (!pause) {
-//     var delay;
-
-//     if (activeIndex == pageNumber - 1 || activeIndex == 0) {
-//       delay = 700;
-//     } else if (
-//       (activeIndex == 1 && !swipedLeft) ||
-//       (activeIndex == pageNumber - 2 && swipedRight)
-//     ) {
-//       delay = 1800;
-//     } else {
-//       delay = 2500;
-//     }
-
-//     const interval = setInterval(() => {
-//       updateIndex(activeIndex + direction);
-//     }, delay);
-
-//     return () => {
-//       if (interval) {
-//         clearInterval(interval);
-//       }
-//     };
-//   }
-// }, [activeIndex, pause, windowWidth]);
-
-// Update Index with loop
-
-export const ActiveButton = (key) => (
-  <div className="inline-block w-[30px] text-center">
-    <div
-      key={key}
-      className={"h-3 w-3 rounded-full bg-bgDark-500 dark:bg-bgDark-400"}
-    />
-  </div>
-);
-
-export const NonActiveButton = (key) => (
-  <div className="inline-block w-[30px] text-center">
-    <div
-      key={key}
-      className={"h-3 w-3 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
-    />
-  </div>
-);
-export const NonActiveButtonS = (key) => (
-  <div className="inline-block w-[30px] text-center">
-    <div
-      key={key}
-      className={"h-2 w-2 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
-    />
-  </div>
-);
-
-export const NonActiveButtonXS = (key) => (
-  <div className="inline-block w-[30px] text-center">
-    <div
-      key={key}
-      className={"h-1 w-1 rounded-full bg-bgDark-300 dark:bg-bgDark-600"}
-    />
-  </div>
-);
 
 export default Carousel;

--- a/src/components/utility/Carousel.jsx
+++ b/src/components/utility/Carousel.jsx
@@ -4,110 +4,50 @@ import { useSwipeable } from "react-swipeable";
 
 export const CarouselItem = ({ children }) => {
   return (
-    <div className="inline-flex w-[100%] items-center justify-center lg:w-[50%] 2xl:w-[33.33%]">
+    <div className="inline-flex w-[100%] items-center justify-center">
       {children}
     </div>
   );
 };
 
-const Carousel = ({ children, homeScreenVisible, scrollY }) => {
+const Carousel = ({ children }) => {
   const childrenNumber = React.Children.count(children);
   const nonRepeatingChildrenNumber = childrenNumber - 2;
 
-  const stopPixel = 250;
-  // TailwindCSS default values
-  const lg = 1024;
-  const doubleXl = 1536;
+  // const stopPixel = 250;
+  // // TailwindCSS default values
+  // const lg = 1024;
+  // const doubleXl = 1536;
 
-  const [windowWidth, windowWidthHandler] = useState(window.innerWidth);
   const [activeIndex, activeIndexHandler] = useState(1);
-  const [pause, pauseHandler] = useState(false);
-  const [itemsOnScreen, itemsOnScreenHandler] = useState(1);
-  const [pageNumber, pageNumberHandler] = useState(childrenNumber);
   const [infiniteLoop, infiniteLoopHandler] = useState(false);
   const [swipedRight, swipedRightHandler] = useState(false);
   const [swipedLeft, swipedLeftHandler] = useState(false);
 
-  // Pause Carousel when scrolling beyond the Section
-  useEffect(() => {
-    if (scrollY > stopPixel) {
-      pauseHandler(true);
-    } else {
-      pauseHandler(false);
-    }
-  }, [scrollY]);
-
-  // Set the activeIndex & pageNumber depending on windowWidth
-  useEffect(() => {
-    function handleWindowResize() {
-      windowWidthHandler(window.innerWidth);
-    }
-
-    window.addEventListener("resize", handleWindowResize);
-
-    if (windowWidth < lg) {
-      activeIndexHandler(1);
-      itemsOnScreenHandler(1);
-      pageNumberHandler(childrenNumber);
-    }
-
-    if (windowWidth > lg && windowWidth < doubleXl) {
-      activeIndexHandler(1);
-      itemsOnScreenHandler(2);
-      pageNumberHandler(Math.ceil(childrenNumber / 2));
-    }
-
-    if (windowWidth > doubleXl) {
-      activeIndexHandler(1);
-      itemsOnScreenHandler(3);
-      pageNumberHandler(Math.ceil(childrenNumber / 3));
-    }
-
-    return () => {
-      window.removeEventListener("resize", handleWindowResize);
-    };
-  }, [windowWidth]);
-
-  // Pause Carousel when there are no pages to slide
-  useEffect(() => {
-    if (childrenNumber <= itemsOnScreen) {
-      pauseHandler(true);
-    } else {
-      pauseHandler(false);
-    }
-  }, [itemsOnScreen]);
-
-  // Pause Carousel if the Home is visible
-  useEffect(() => {
-    if (homeScreenVisible) {
-      pauseHandler(true);
-    } else {
-      pauseHandler(false);
-    }
-  }, [homeScreenVisible]);
-
   // Illusion for infinite loop - Disable Swipe Animation
   useEffect(() => {
     if (
-      (activeIndex == pageNumber - 1 && swipedLeft) ||
+      (activeIndex == childrenNumber - 1 && swipedLeft) ||
       (activeIndex == 0 && swipedRight)
     ) {
-      const timeout = setTimeout(() => {
+      setTimeout(() => {
         infiniteLoopHandler(true);
-        return clearTimeout(timeout);
-      }, 700);
+      }, 600);
     } else {
-      infiniteLoopHandler(false);
+      setTimeout(() => {
+        infiniteLoopHandler(false);
+      }, 10);
     }
   }, [activeIndex]);
 
   // Illusion for infinite loop - Active Index Cycle
   useEffect(() => {
+    console.log(infiniteLoop);
     if (infiniteLoop) {
-      if (activeIndex == pageNumber - 1) {
+      if (activeIndex == childrenNumber - 1) {
         updateIndex(1);
       } else {
-        updateIndex(pageNumber - 2);
+        updateIndex(childrenNumber - 2);
       }
     }
   }, [infiniteLoop]);
@@ -115,11 +55,17 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
   //  Swipe Carousel on phone screens
   const handlers = useSwipeable({
     onSwipedLeft: () => {
+      if (activeIndex == childrenNumber - 1 || activeIndex == 0) {
+        return;
+      }
       swipedRightHandler(false);
       swipedLeftHandler(true);
       updateIndex(activeIndex + 1);
     },
     onSwipedRight: () => {
+      if (activeIndex == childrenNumber - 1 || activeIndex == 0) {
+        return;
+      }
       swipedLeftHandler(false);
       swipedRightHandler(true);
       updateIndex(activeIndex - 1);
@@ -130,8 +76,8 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
   const updateIndex = (newIndex) => {
     if (newIndex < 0) {
       newIndex = 0;
-    } else if (newIndex > pageNumber - 1) {
-      newIndex = pageNumber - 1;
+    } else if (newIndex > childrenNumber - 1) {
+      newIndex = childrenNumber - 1;
     }
     activeIndexHandler(newIndex);
   };
@@ -139,8 +85,8 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
   // Cycle thought activeIndexes
   const carouselIndex = (index) => {
     if (index == 0) {
-      return pageNumber - 2;
-    } else if (index == pageNumber - 1) {
+      return childrenNumber - 2;
+    } else if (index == childrenNumber - 1) {
       return 1;
     } else {
       return index;
@@ -294,11 +240,10 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
     <div className="overflow-hidden">
       <div
         {...handlers}
-        onMouseEnter={() => pauseHandler(true)}
-        onMouseLeave={() => pauseHandler(false)}
         className={`whitespace-nowrap ${
           infiniteLoop ? "" : "transition-transform duration-[600ms]"
-        }`}
+        }
+          `}
         style={{
           transform: `translateX(-${activeIndex * 100}%)`,
         }}
@@ -307,7 +252,6 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
           return child;
         })}
       </div>
-
       <div className="mx-auto mt-6 h-fit w-[150px] overflow-hidden border-2 border-red-500">
         <div
           className={`whitespace-nowrap ${
@@ -318,7 +262,7 @@ const Carousel = ({ children, homeScreenVisible, scrollY }) => {
           }}
         >
           {React.Children.map(children, (child, index) => {
-            if (index > 0 && index < pageNumber - 1) {
+            if (index > 0 && index < childrenNumber - 1) {
               if (index === carouselIndex(activeIndex)) {
                 return <ActiveButton index={index} />;
               } else {

--- a/src/components/utility/CarouselBigScreens.jsx
+++ b/src/components/utility/CarouselBigScreens.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useEffect } from "react";
 import { useSwipeable } from "react-swipeable";
 
-export const CarouselPhoneItem = ({ children }) => {
+export const CarouselBigScreensItem = ({ children }) => {
   return (
     <div className="inline-flex w-[100%] items-center justify-center">
       {children}
@@ -10,7 +10,7 @@ export const CarouselPhoneItem = ({ children }) => {
   );
 };
 
-const CarouselPhone = ({ children }) => {
+const CarouselBigScreens = ({ children }) => {
   const childrenNumber = React.Children.count(children);
   const nonRepeatingChildrenNumber = childrenNumber - 2;
 
@@ -246,7 +246,7 @@ const CarouselPhone = ({ children }) => {
           return child;
         })}
       </div>
-      <div className="mx-auto mt-6 h-fit w-[150px] overflow-hidden">
+      <div className="mx-auto mt-6 h-fit w-[150px] overflow-hidden border-2 border-red-500">
         <div
           className={`whitespace-nowrap ${
             infiniteLoop ? "" : "transition-transform duration-[600ms]"
@@ -276,4 +276,4 @@ const CarouselPhone = ({ children }) => {
   );
 };
 
-export default CarouselPhone;
+export default CarouselBigScreens;

--- a/src/components/utility/CarouselPhone.jsx
+++ b/src/components/utility/CarouselPhone.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { useEffect } from "react";
 import { useSwipeable } from "react-swipeable";
 
-export const CarouselItem = ({ children }) => {
+export const CarouselPhoneItem = ({ children }) => {
   return (
     <div className="inline-flex w-[100%] items-center justify-center">
       {children}
@@ -10,7 +10,7 @@ export const CarouselItem = ({ children }) => {
   );
 };
 
-const Carousel = ({ children }) => {
+const CarouselPhone = ({ children }) => {
   const childrenNumber = React.Children.count(children);
   const nonRepeatingChildrenNumber = childrenNumber - 2;
 
@@ -281,4 +281,4 @@ const Carousel = ({ children }) => {
   );
 };
 
-export default Carousel;
+export default CarouselPhone;

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -34,18 +34,18 @@ export default [
     stack: ["Bootstrap", "ExpressJS"],
     link: "https://github.com/alextsagkas/Newsletter-NodeJS",
   },
-  {
-    id: 5,
-    title: "Simon Game",
-    imgUrl: "assets/simon-game.png",
-    stack: ["html", "CSS", "JS"],
-    link: "https://alextsagkas.github.io/Simon-Game/",
-  },
-  {
-    id: 6,
-    title: "Computational Physics",
-    imgUrl: "assets/computational-physics.png",
-    stack: ["Python", "Numpy", "Matplotlib"],
-    link: "https://github.com/alextsagkas/CompPhysics/tree/master/studentsCode/AlexTsagkas",
-  },
+  // {
+  //   id: 5,
+  //   title: "Simon Game",
+  //   imgUrl: "assets/simon-game.png",
+  //   stack: ["html", "CSS", "JS"],
+  //   link: "https://alextsagkas.github.io/Simon-Game/",
+  // },
+  // {
+  //   id: 6,
+  //   title: "Computational Physics",
+  //   imgUrl: "assets/computational-physics.png",
+  //   stack: ["Python", "Numpy", "Matplotlib"],
+  //   link: "https://github.com/alextsagkas/CompPhysics/tree/master/studentsCode/AlexTsagkas",
+  // },
 ];

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -34,18 +34,18 @@ export default [
     stack: ["Bootstrap", "ExpressJS"],
     link: "https://github.com/alextsagkas/Newsletter-NodeJS",
   },
-  // {
-  //   id: 5,
-  //   title: "Simon Game",
-  //   imgUrl: "assets/simon-game.png",
-  //   stack: ["html", "CSS", "JS"],
-  //   link: "https://alextsagkas.github.io/Simon-Game/",
-  // },
-  // {
-  //   id: 6,
-  //   title: "Computational Physics",
-  //   imgUrl: "assets/computational-physics.png",
-  //   stack: ["Python", "Numpy", "Matplotlib"],
-  //   link: "https://github.com/alextsagkas/CompPhysics/tree/master/studentsCode/AlexTsagkas",
-  // },
+  {
+    id: 5,
+    title: "Simon Game",
+    imgUrl: "assets/simon-game.png",
+    stack: ["html", "CSS", "JS"],
+    link: "https://alextsagkas.github.io/Simon-Game/",
+  },
+  {
+    id: 6,
+    title: "Computational Physics",
+    imgUrl: "assets/computational-physics.png",
+    stack: ["Python", "Numpy", "Matplotlib"],
+    link: "https://github.com/alextsagkas/CompPhysics/tree/master/studentsCode/AlexTsagkas",
+  },
 ];


### PR DESCRIPTION
Removed carousel automatic motion and implemented different views for phone and larger screens:

- On phone screens the user can slide the portfolio items and press the bullets above to navigate through them. Also, the carousel supports infinite loop feature
- On big screens the user can navigate with left and right buttons, or bullets. The carousel does not support infinite loop feature duo to ugliness  